### PR TITLE
feat: APIキー形式バリデーションを追加

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from datetime import datetime
 from src.logger import logger
 
@@ -208,3 +209,43 @@ def update_gladia_usage(config_data, seconds):
 
     remaining = 36000 - config_data["gladia_usage_seconds"]
     logger.info(f"Gladia usage: {config_data['gladia_usage_seconds']}s / 36000s (Remaining: {remaining}s / {remaining/3600:.1f}h)")
+
+
+def validate_deepl_api_key(key: str) -> tuple[bool, str]:
+    """
+    DeepL APIキーの形式を検証
+
+    Args:
+        key: DeepL APIキー
+
+    Returns:
+        (is_valid, error_message)
+    """
+    if not key:
+        return False, "DeepL APIキーが入力されていません"
+    key = key.strip()
+    # DeepL Free: ends with :fx, Pro: UUID-like format
+    if key.endswith(":fx") and len(key) > 3:
+        return True, ""
+    if re.match(r'^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$', key.lower()):
+        return True, ""
+    return False, "DeepL APIキーの形式が正しくありません（Free版は:fxで終わる形式、Pro版はUUID形式）"
+
+
+def validate_twitch_client_id(client_id: str) -> tuple[bool, str]:
+    """
+    Twitch Client IDの形式を検証
+
+    Args:
+        client_id: Twitch Client ID
+
+    Returns:
+        (is_valid, error_message)
+    """
+    if not client_id:
+        return False, "Twitch Client IDが入力されていません"
+    client_id = client_id.strip()
+    # Twitch Client ID: 30 alphanumeric characters
+    if re.match(r'^[a-z0-9]{30}$', client_id.lower()):
+        return True, ""
+    return False, "Twitch Client IDの形式が正しくありません（30文字の英数字）"


### PR DESCRIPTION
## Summary
- DeepL APIキーの形式チェック（Free版:fx終端、Pro版UUID形式）
- Twitch Client IDの形式チェック（30文字英数字）
- 設定保存時に形式を検証し、不正な場合は警告を表示

## 変更内容
### src/config.py
- `validate_deepl_api_key()` 関数を追加
- `validate_twitch_client_id()` 関数を追加

### src/gui.py
- `save_settings()` でバリデーション実行
- 不正な形式の場合は警告ダイアログを表示

## Test plan
- [ ] 正常なDeepL Free APIキー（xxx:fx形式）で警告が出ないこと
- [ ] 正常なDeepL Pro APIキー（UUID形式）で警告が出ないこと
- [ ] 正常なTwitch Client ID（30文字英数字）で警告が出ないこと
- [ ] 不正な形式で適切な警告が表示されること
- [ ] 空欄の場合は警告なしで保存されること

Partial fix for #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)