### PR TITLE
feat: tenacityによる指数バックオフリトライを導入

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,9 @@ twitchio>=2.9.0,<3.0.0
 requests>=2.31.0,<3.0.0
 aiohttp>=3.9.0,<4.0.0
 
+# Retry with exponential backoff
+tenacity>=8.2.0
+
 # Environment Variables
 python-dotenv>=1.0.0,<2.0.0
 


### PR DESCRIPTION
## Summary
- tenacityライブラリを追加
- DeepL APIに指数バックオフリトライを適用（3回まで、1-10秒間隔）
- Gladia APIセッション初期化にリトライを追加
- 手動リトライループを削除してコードを簡潔化

## 変更内容
### requirements.txt
- `tenacity>=8.2.0` を追加

### src/translator.py
- `DeepLRetryableError` 例外クラスを追加
- `_translate_http_async` / `_translate_http_sync` に `@retry` デコレータを適用
- 429/503エラー時に自動リトライ（指数バックオフ）
- 手動リトライループを削除

### src/voice_listener.py
- `_init_gladia_session` メソッドを追加（リトライ付き）
- Gladia APIセッション初期化時のエラーに対してリトライ

## Test plan
- [ ] DeepL API正常時の翻訳動作確認
- [ ] DeepL API 429エラー時のリトライ動作確認
- [ ] Gladia APIセッション初期化の動作確認

Partial fix for #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)