### PR TITLE
fix: filedialog全画面表示バグを修正

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -2230,6 +2230,7 @@ class TwitchBotApp:
     def browse_voicevox_path(self):
         """VOICEVOX Engineの実行ファイルを選択"""
         file_path = filedialog.askopenfilename(
+            parent=self.master,
             title="VOICEVOX Engineの実行ファイルを選択（run.exe）",
             filetypes=[
                 ("実行ファイル", "*.exe" if platform.system() == "Windows" else "*"),
@@ -3324,6 +3325,7 @@ window.onload = function() {{
     def select_event_sound(self, event_type: str):
         """効果音ファイルを選択"""
         file_path = filedialog.askopenfilename(
+            parent=self.master,
             title="効果音ファイルを選択",
             filetypes=[
                 ("Audio files", "*.mp3 *.wav *.ogg"),
@@ -3448,6 +3450,7 @@ window.onload = function() {{
 
         # ファイル保存ダイアログ
         file_path = filedialog.asksaveasfilename(
+            parent=self.master,
             defaultextension=".txt",
             filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
             initialfile=f"chatlog_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt"
@@ -3483,6 +3486,7 @@ window.onload = function() {{
 
         # ファイル保存ダイアログ
         file_path = filedialog.asksaveasfilename(
+            parent=self.master,
             defaultextension=".json",
             filetypes=[("JSON files", "*.json"), ("All files", "*.*")],
             initialfile=f"chatlog_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"


### PR DESCRIPTION
## Summary
イベント効果音の参照ボタンをクリックした際の全画面表示バグを修正

## 原因
`filedialog` の呼び出し時に `parent` 引数が指定されていなかったため、
ダイアログがメインウィンドウに紐付かず、全画面表示になる問題が発生していました。

## 修正内容
以下の4箇所に `parent=self.master` 引数を追加:

1. `browse_voicevox_path()` - VOICEVOXパス選択
2. `select_event_sound()` - 効果音ファイル選択
3. `export_log_text()` - テキストログ出力
4. `export_log_json()` - JSONログ出力

## Test plan
- [ ] 効果音の参照ボタンをクリックしてダイアログが正常に表示されること
- [ ] VOICEVOXパス選択ダイアログが正常に表示されること
- [ ] ログ出力ダイアログが正常に表示されること

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)