### PR TITLE
feat: ログレベル動的切り替え機能を追加

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -43,11 +43,14 @@ DEFAULT_CONFIG = {
     "chat_html_newest_first": False,  # True: 上が新しい, False: 下が新しい
     # UI テーマ
     "ui_theme": "default",  # default / gradient / minimal / cyberpunk
+    # ログ設定
+    "log_level": "INFO",  # DEBUG / INFO / WARNING / ERROR
 }
 
 VALID_TRANSLATE_MODES = {"自動", "英→日", "日→英"}
 VALID_UI_THEMES = {"default", "gradient", "minimal", "cyberpunk"}
 VALID_CHANNEL_MODES = {"auto", "manual"}
+VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR"}
 
 def validate_config(config_data):
     """
@@ -75,6 +78,15 @@ def validate_config(config_data):
         logger.warning(f"channel_mode is invalid: {validated.get('channel_mode')}, fallback to manual")
         validated["channel_mode"] = "manual"
         changed = True
+
+    # log_level
+    log_level = validated.get("log_level", "INFO").upper()
+    if log_level not in VALID_LOG_LEVELS:
+        logger.warning(f"log_level is invalid: {log_level}, fallback to INFO")
+        validated["log_level"] = "INFO"
+        changed = True
+    else:
+        validated["log_level"] = log_level
 
     # ブール値はbool化
     for key in ["voicevox_auto_start"]:

--- a/src/gui.py
+++ b/src/gui.py
@@ -28,7 +28,7 @@ from src.bot import TranslateBot
 from src.config import load_config, save_config
 from src.voice_listener import VoiceTranslator
 from src.overlay_server import update_translation, run_server_thread
-from src.logger import logger
+from src.logger import logger, set_log_level
 from src.tts import get_tts_instance
 from src.tts_dictionary import get_dictionary
 from src.participant_tracker import get_tracker
@@ -333,6 +333,23 @@ class TwitchBotApp:
         # ユーザーに通知
         self.log_message(f"✨ テーマを '{THEMES[theme_key]['name']}' に変更しました")
         self.log_message("⚠️ 一部の色変更を反映するには、アプリを再起動してください")
+
+    def _on_log_level_changed(self, level: str):
+        """
+        ログレベル選択が変更されたときのコールバック
+
+        Args:
+            level: ログレベル (DEBUG, INFO, WARNING, ERROR)
+        """
+        # ログレベルを動的に変更
+        set_log_level(level)
+
+        # 設定を保存
+        self.config["log_level"] = level.upper()
+        save_config(self.config)
+
+        # ユーザーに通知
+        self.log_message(f"📝 ログレベルを '{level}' に変更しました")
 
     def build_widgets(self):
         """新レイアウト: ヘッダー + 左サイドバー + メインコンテンツ + 折りたたみ右パネル"""
@@ -915,6 +932,13 @@ class TwitchBotApp:
         display_map = {"default": theme_names[0], "gradient": theme_names[1], "minimal": theme_names[2], "cyberpunk": theme_names[3]}
         self.ui_theme_var = tk.StringVar(value=display_map.get(current_key, theme_names[0]))
         ctk.CTkOptionMenu(parent, values=theme_names, variable=self.ui_theme_var, command=self._on_theme_changed, width=280).pack(fill="x", pady=(0, 8))
+
+        # ログレベル
+        self._add_panel_section(parent, "ログレベル")
+        log_levels = ["DEBUG", "INFO", "WARNING", "ERROR"]
+        current_log_level = self.config.get("log_level", "INFO").upper()
+        self.log_level_var = tk.StringVar(value=current_log_level)
+        ctk.CTkOptionMenu(parent, values=log_levels, variable=self.log_level_var, command=self._on_log_level_changed, width=280).pack(fill="x", pady=(0, 8))
 
         self._add_panel_divider(parent)
 

--- a/src/logger.py
+++ b/src/logger.py
@@ -80,5 +80,47 @@ def setup_logger(name: str = "TwitchTranslateBOT", level: str = "INFO") -> loggi
     return logger
 
 
+def set_log_level(level: str) -> None:
+    """
+    ログレベルを動的に変更する
+
+    Args:
+        level: ログレベル (DEBUG, INFO, WARNING, ERROR)
+    """
+    level_map = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+    }
+    log_level = level_map.get(level.upper(), logging.INFO)
+
+    # ルートロガーとすべてのハンドラのレベルを変更
+    root_logger = logging.getLogger("TwitchTranslateBOT")
+    root_logger.setLevel(log_level)
+
+    for handler in root_logger.handlers:
+        handler.setLevel(log_level)
+
+    root_logger.info(f"Log level changed to: {level.upper()}")
+
+
+def get_log_level() -> str:
+    """
+    現在のログレベルを取得する
+
+    Returns:
+        現在のログレベル文字列
+    """
+    level_names = {
+        logging.DEBUG: "DEBUG",
+        logging.INFO: "INFO",
+        logging.WARNING: "WARNING",
+        logging.ERROR: "ERROR",
+    }
+    root_logger = logging.getLogger("TwitchTranslateBOT")
+    return level_names.get(root_logger.level, "INFO")
+
+
 # Create default logger instance
 logger = setup_logger()


### PR DESCRIPTION
## Summary
GUIからログレベルを動的に切り替えられる機能を追加

## 変更内容
### src/logger.py
- `set_log_level()` 関数を追加
- `get_log_level()` 関数を追加
- ログレベルを実行時に動的変更可能に

### src/config.py
- `log_level` 設定を追加（デフォルト: INFO）
- `VALID_LOG_LEVELS` を追加（DEBUG/INFO/WARNING/ERROR）
- validate_config()でログレベルのバリデーション追加

### src/gui.py
- ログレベル選択UIを追加（UIテーマの下）
- `_on_log_level_changed()` コールバックを追加
- 変更時に設定を保存し、即座に反映

## Test plan
- [ ] ログレベルを変更して設定が保存されること
- [ ] DEBUGレベルで詳細なログが出力されること
- [ ] ERRORレベルでエラーログのみ出力されること

Partial fix for #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)