### PR TITLE
feat: Sentry SDK 配線とPII除去フックを追加 (#208 PR1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,4 +26,6 @@ dependencies = [
     "obsws-python>=1.7.2",
     # Edge TTS（オンライン・APIキー不要）
     "edge-tts>=7.0.0",
+    # クラッシュレポート送信（オプトイン、PR2 でUI追加予定）
+    "sentry-sdk>=2.0.0",
 ]

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -15,3 +15,4 @@ websockets
 tenacity
 psutil
 edge-tts
+sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ aiohappyeyeballs==2.6.1
     # via aiohttp
 aiohttp==3.13.3
     # via
+    #   edge-tts
     #   translation-bot
     #   twitchio
 aiosignal==1.4.0
@@ -11,7 +12,10 @@ aiosignal==1.4.0
 attrs==26.1.0
     # via aiohttp
 certifi==2026.2.25
-    # via requests
+    # via
+    #   edge-tts
+    #   requests
+    #   sentry-sdk
 cffi==2.0.0
     # via sounddevice
 charset-normalizer==3.4.6
@@ -24,6 +28,8 @@ customtkinter==5.2.2
     # via translation-bot
 darkdetect==0.8.0
     # via customtkinter
+edge-tts==7.2.8
+    # via translation-bot
 flatbuffers==25.12.19
     # via onnxruntime
 frozenlist==1.8.0
@@ -36,6 +42,8 @@ idna==3.11
     # via
     #   requests
     #   yarl
+iso8601==2.1.0
+    # via twitchio
 mpmath==1.3.0
     # via sympy
 multidict==6.7.1
@@ -47,6 +55,8 @@ numpy==2.4.3
     #   ctranslate2
     #   onnxruntime
     #   translation-bot
+obsws-python==1.8.0
+    # via translation-bot
 onnxruntime==1.23.2
     # via translation-bot
 packaging==26.0
@@ -61,10 +71,6 @@ propcache==0.4.1
     #   yarl
 protobuf==7.34.1
     # via onnxruntime
-obsws-python==1.8.0
-    # via translation-bot
-websocket-client==1.9.0
-    # via obsws-python
 psutil==7.2.2
     # via translation-bot
 pycparser==3.0 ; implementation_name != 'PyPy'
@@ -81,6 +87,8 @@ requests==2.33.0
     # via translation-bot
 sentencepiece==0.2.1
     # via translation-bot
+sentry-sdk==2.59.0
+    # via translation-bot
 setuptools==82.0.1
     # via ctranslate2
 sherpa-onnx==1.12.33
@@ -91,11 +99,20 @@ sounddevice==0.5.5
     # via translation-bot
 sympy==1.14.0
     # via onnxruntime
+tabulate==0.10.0
+    # via edge-tts
 twitchio==2.10.0
     # via translation-bot
-typing-extensions==4.15.0 ; python_full_version < '3.13'
-    # via aiosignal
+typing-extensions==4.15.0
+    # via
+    #   aiosignal
+    #   edge-tts
+    #   twitchio
 urllib3==2.6.3
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
+websocket-client==1.9.0
+    # via obsws-python
 yarl==1.23.0
     # via aiohttp

--- a/src/sentry_init.py
+++ b/src/sentry_init.py
@@ -1,0 +1,172 @@
+"""
+Sentry SDK 初期化とイベントスクラブ。
+
+PR1 ではモジュールのみ用意し、`init_sentry()` の呼び出しは PR2（オプトイン UI）で
+config フラグ参照と合わせて main.py に追加する想定。
+
+設計方針:
+- 配信者向けツールという性質上、PII（チャンネル名・コメント本文・トークン等）を
+  Sentry に送らない。`_scrub_event` で `before_send` フックとして除去する。
+- `sentry-sdk` が import 失敗しても本体起動は止めない（外部依存のため）。
+- Tkinter のボタンコールバック例外は `Tk.report_callback_exception` を上書きして
+  Sentry に転送する（標準の sys.excepthook では拾えないため）。
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from typing import Any, Optional
+
+from src import __version__
+from src.logger import _mask_secrets
+
+# 公開可能な DSN 定数（Sentry 設計上、クライアント配布アプリでは公開で問題ない）
+# 環境変数 KOTOTSUNA_SENTRY_DSN で上書き可能
+_DEFAULT_DSN = (
+    "https://ae70bf69c755394587c8d7439e5b91c9"
+    "@o4511336076476416.ingest.us.sentry.io/4511336079294464"
+)
+
+# event の extra / breadcrumb data から伏せ字にするキー
+_REDACT_KEYS = frozenset({
+    "channel", "channel_name", "username", "display_name", "user",
+    "message", "comment", "text", "content",
+    "oauth", "oauth_token", "access_token", "refresh_token",
+    "client_secret", "password", "token",
+})
+
+_REDACTED = "***"
+
+_module_logger = logging.getLogger("KototsunaBot")
+
+
+def _redact_mapping(data: Any) -> Any:
+    """dict / list を再帰的に走査して機微キーを伏せ字にする。"""
+    if isinstance(data, dict):
+        return {
+            k: (_REDACTED if k.lower() in _REDACT_KEYS else _redact_mapping(v))
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [_redact_mapping(x) for x in data]
+    if isinstance(data, str):
+        return _mask_secrets(data)
+    return data
+
+
+def _scrub_event(event: dict, hint: dict) -> Optional[dict]:
+    """before_send フック: PII を除去し、無害な例外をドロップする。"""
+    # 既知の無害例外はドロップ
+    exc_info = hint.get("exc_info")
+    if exc_info:
+        exc_type = exc_info[0]
+        if exc_type is KeyboardInterrupt or exc_type is SystemExit:
+            return None
+
+    # ユーザー情報は送らない
+    event.pop("user", None)
+
+    # メッセージ・例外メッセージにシークレットマスクを適用
+    if "message" in event and isinstance(event["message"], str):
+        event["message"] = _mask_secrets(event["message"])
+
+    for exc in event.get("exception", {}).get("values", []) or []:
+        if isinstance(exc.get("value"), str):
+            exc["value"] = _mask_secrets(exc["value"])
+        # ローカル変数（vars）はそもそも with_locals=False で送らない設定だが念のため除去
+        for frame in exc.get("stacktrace", {}).get("frames", []) or []:
+            frame.pop("vars", None)
+
+    # extra / contexts / breadcrumbs を再帰的に伏せ字
+    if "extra" in event:
+        event["extra"] = _redact_mapping(event["extra"])
+    if "contexts" in event:
+        event["contexts"] = _redact_mapping(event["contexts"])
+
+    for crumb in event.get("breadcrumbs", {}).get("values", []) or []:
+        if isinstance(crumb.get("message"), str):
+            crumb["message"] = _mask_secrets(crumb["message"])
+        if "data" in crumb:
+            crumb["data"] = _redact_mapping(crumb["data"])
+
+    return event
+
+
+def _install_tk_excepthook() -> None:
+    """Tkinter コールバック内の例外を Sentry に転送するフックを仕込む。
+
+    Tk はコールバック例外を独自の `report_callback_exception` で処理するため、
+    sys.excepthook では拾えない。クラス側を上書きすることで CustomTkinter の
+    `CTk` などサブクラスにも一括適用される。
+    """
+    try:
+        import tkinter as tk
+        import sentry_sdk
+    except Exception:
+        return
+
+    _original = tk.Tk.report_callback_exception
+
+    def _hooked(self, exc, val, tb):
+        try:
+            sentry_sdk.capture_exception((exc, val, tb))
+        except Exception:
+            pass
+        try:
+            _original(self, exc, val, tb)
+        except Exception:
+            pass
+
+    tk.Tk.report_callback_exception = _hooked  # type: ignore[assignment]
+
+
+def init_sentry(enabled: bool, dsn: Optional[str] = None) -> bool:
+    """Sentry SDK を初期化する。
+
+    Args:
+        enabled: ユーザーがクラッシュレポート送信に同意しているかどうか。
+                 False の場合は何もせず即座に False を返す（=送信されない）。
+        dsn: 明示的に DSN を指定する場合に渡す。省略時は環境変数 → 定数 の順。
+
+    Returns:
+        実際に初期化が走った場合 True。同意なし / SDK欠落 / DSN欠落時は False。
+    """
+    if not enabled:
+        return False
+
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.logging import LoggingIntegration
+    except ImportError:
+        _module_logger.warning(
+            "[Sentry] sentry-sdk が import できないためテレメトリを無効化します"
+        )
+        return False
+
+    effective_dsn = dsn or os.environ.get("KOTOTSUNA_SENTRY_DSN") or _DEFAULT_DSN
+    if not effective_dsn:
+        return False
+
+    try:
+        sentry_sdk.init(
+            dsn=effective_dsn,
+            release=f"kototsuna@{__version__}",
+            environment="production" if getattr(sys, "frozen", False) else "development",
+            send_default_pii=False,
+            traces_sample_rate=0.0,
+            max_breadcrumbs=50,
+            attach_stacktrace=False,
+            include_local_variables=False,
+            before_send=_scrub_event,
+            integrations=[
+                LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+            ],
+        )
+    except Exception as e:
+        _module_logger.warning(f"[Sentry] init に失敗しました: {e}")
+        return False
+
+    _install_tk_excepthook()
+    _module_logger.info(f"[Sentry] initialized (release=kototsuna@{__version__})")
+    return True

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -1,0 +1,109 @@
+"""src/sentry_init.py のテスト。
+
+PII スクラブと無害例外ドロップを検証する。実際の Sentry SDK は不要
+（`init_sentry()` は `enabled=False` または SDK 不在時に安全に no-op になる）。
+"""
+from src.sentry_init import _redact_mapping, _scrub_event, init_sentry
+
+
+def test_init_sentry_disabled_returns_false():
+    assert init_sentry(False) is False
+
+
+def test_scrub_removes_user_field():
+    event = {"user": {"id": "streamer1", "ip": "1.2.3.4"}}
+    out = _scrub_event(event, {})
+    assert "user" not in out
+
+
+def test_scrub_masks_oauth_token_in_message():
+    event = {"message": "login with oauth:abcdef1234567890"}
+    out = _scrub_event(event, {})
+    assert "oauth:***" in out["message"]
+    assert "abcdef1234567890" not in out["message"]
+
+
+def test_scrub_redacts_pii_keys_in_extra():
+    event = {
+        "extra": {
+            "channel": "kototsuna_test",
+            "comment": "hello",
+            "username": "viewer1",
+            "safe_field": 42,
+        }
+    }
+    out = _scrub_event(event, {})
+    assert out["extra"]["channel"] == "***"
+    assert out["extra"]["comment"] == "***"
+    assert out["extra"]["username"] == "***"
+    assert out["extra"]["safe_field"] == 42
+
+
+def test_scrub_redacts_breadcrumb_data():
+    event = {
+        "breadcrumbs": {
+            "values": [
+                {
+                    "message": "Bearer XYZABCDEF1234567",
+                    "data": {"username": "foo", "channel": "bar"},
+                }
+            ]
+        }
+    }
+    out = _scrub_event(event, {})
+    crumb = out["breadcrumbs"]["values"][0]
+    assert "Bearer ***" in crumb["message"]
+    assert crumb["data"]["username"] == "***"
+    assert crumb["data"]["channel"] == "***"
+
+
+def test_scrub_strips_local_vars_from_stacktrace():
+    event = {
+        "exception": {
+            "values": [
+                {
+                    "value": "boom",
+                    "stacktrace": {"frames": [{"vars": {"tok": "secret"}}]},
+                }
+            ]
+        }
+    }
+    out = _scrub_event(event, {})
+    frame = out["exception"]["values"][0]["stacktrace"]["frames"][0]
+    assert "vars" not in frame
+
+
+def test_scrub_drops_keyboard_interrupt():
+    event = {"message": "interrupted"}
+    out = _scrub_event(event, {"exc_info": (KeyboardInterrupt, KeyboardInterrupt(), None)})
+    assert out is None
+
+
+def test_scrub_drops_system_exit():
+    event = {"message": "exit"}
+    out = _scrub_event(event, {"exc_info": (SystemExit, SystemExit(), None)})
+    assert out is None
+
+
+def test_scrub_keeps_real_exception():
+    class MyErr(Exception):
+        pass
+
+    event = {"message": "real bug"}
+    out = _scrub_event(event, {"exc_info": (MyErr, MyErr("boom"), None)})
+    assert out is not None
+    assert out["message"] == "real bug"
+
+
+def test_redact_mapping_recurses_into_nested_dicts():
+    data = {"safe": 1, "level1": {"channel": "x", "ok": "y"}}
+    out = _redact_mapping(data)
+    assert out["safe"] == 1
+    assert out["level1"]["channel"] == "***"
+    assert out["level1"]["ok"] == "y"
+
+
+def test_redact_mapping_masks_strings():
+    data = {"note": "token leaked: oauth:abcdef1234567890"}
+    out = _redact_mapping(data)
+    assert "oauth:***" in out["note"]

--- a/uv.lock
+++ b/uv.lock
@@ -1037,6 +1037,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.59.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/e0/9bf5e5fc7442b10880f3ec0eff0ef4208b84a099606f343ec4f5445227fb/sentry_sdk-2.59.0.tar.gz", hash = "sha256:cd265808ef8bf3f3edf69b527c0a0b2b6b1322762679e55b8987db2e9584aec1", size = 447331, upload-time = "2026-05-04T12:19:06.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/00/b8cc413748fb6383d1582e7cda51314f99743351c462a92dc690d5b5853b/sentry_sdk-2.59.0-py2.py3-none-any.whl", hash = "sha256:abcf65ee9a9d9cdebf9ad369782408ecca9c1c792686ef06ba34f5ab233527fe", size = 468432, upload-time = "2026-05-04T12:19:04.741Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "82.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1147,6 +1160,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "sentencepiece" },
+    { name = "sentry-sdk" },
     { name = "sherpa-onnx" },
     { name = "sherpa-onnx-core" },
     { name = "sounddevice" },
@@ -1168,6 +1182,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "sentencepiece", specifier = ">=0.1.99" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sherpa-onnx", specifier = "==1.12.33" },
     { name = "sherpa-onnx-core", specifier = "==1.12.33" },
     { name = "sounddevice", specifier = ">=0.4" },


### PR DESCRIPTION
## 概要

Issue #208 の **PR1**。Sentry SDK の配線と PII 除去 (`before_send` フック) を追加します。

このPR単体では何も送信しません（`init_sentry()` を main.py から呼んでいないため）。オプトイン同意UI（PR2）が完成してから実際の送信が始まる構成です。

## 変更点

- `pyproject.toml` / `requirements.txt` / `requirements-ci.txt` に `sentry-sdk>=2.0.0` を追加
- **`src/sentry_init.py` を新設**
  - `init_sentry(enabled, dsn=None)`: `enabled=False` または SDK 欠落時は no-op で `False` を返す
  - `_scrub_event`: チャンネル名・コメント本文・OAuth トークン等を伏せ字／除去
  - `_install_tk_excepthook`: Tkinter コールバック例外を Sentry に転送（標準 `sys.excepthook` では拾えないため）
- `tests/test_sentry_init.py` を新設（11件、全パス）

## カバー範囲（最終的に PR4 まで完了後）

| 種別 | 状態 |
|---|---|
| 未捕捉例外 | ✅ |
| `logger.error()` / `logger.exception()` | ✅ LoggingIntegration |
| Tkinter ボタンコールバック | ✅ 専用フック |
| asyncio タスク例外 | ✅ Sentry の AsyncioIntegration |
| `except Exception: pass` で握り潰してる箇所 | ❌ 個別に `logger.exception()` への置き換え必要（別Issueで継続対応） |
| Sentry init 以前のクラッシュ（PyInstaller bootstrap 等） | ❌ → 既存の `kototsuna_error.txt` でカバー継続 |

## リリース計画

本機能（PR1〜PR4）は次の流れで段階的に出す:

1. PR1〜PR4 をすべて積み終わったあと、**まずベータ版で1度リリース**して検証
2. 問題なければ **`1.9.0` 安定版** に乗せて公開

テレメトリ（外部送信）が絡むため、安定版直行はせずベータでの実環境検証を1段挟む。

## 受け入れ基準

- [x] `init_sentry(False)` が no-op で `False` を返す
- [x] PII（user / channel / comment / oauth / token 等）が `_scrub_event` で除去・伏せ字
- [x] `KeyboardInterrupt` / `SystemExit` がドロップされる
- [x] `src/logger.py` の `_mask_secrets` を流用しシークレットマスクの正規表現を一元化
- [x] `tests/test_sentry_init.py` 11件パス

## Test plan

- [ ] CI で `tests/test_sentry_init.py` がグリーン
- [ ] 既存テストにリグレッションが無いこと
- [ ] Windows ローカルで `python -m pytest tests/test_sentry_init.py -v` がパス

Refs #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
