### PR TITLE
feat: クラッシュレポート送信のオプトインUI (#208 PR2)

### DIFF
--- a/main.py
+++ b/main.py
@@ -217,6 +217,16 @@ import concurrent.futures  # noqa: F401
 # ロガーを最初にインポート（他のモジュールより先に初期化）
 from src.logger import logger  # noqa: E402
 
+# Sentry はオプトイン同意済みのときだけ起動。同意なしまたは SDK 欠落時は no-op。
+# 起点をできるだけ早くするため、heavy import の前に呼ぶ。
+try:
+    from src.config import load_config as _load_config_for_sentry  # noqa: E402
+    from src.sentry_init import init_sentry as _init_sentry  # noqa: E402
+    _init_sentry(bool(_load_config_for_sentry().get("telemetry_crash_reporting", False)))
+except Exception:
+    # 設定読み込みやSentry初期化に失敗しても本体起動は止めない
+    pass
+
 import customtkinter as ctk  # noqa: E402
 import src.overlay_server  # noqa: E402
 import src.voice_listener  # noqa: E402

--- a/src/config.py
+++ b/src/config.py
@@ -159,6 +159,9 @@ DEFAULT_CONFIG = {
     "game_roulette_cooldown": 10,   # ルーレットクールダウン（秒）
     "game_janken_cooldown": 5,      # じゃんけんクールダウン（秒）
     "game_guess_cooldown": 3,       # 数字当てクールダウン（秒）
+    # テレメトリ（クラッシュレポート送信、Issue #208）
+    "telemetry_crash_reporting": False,   # Sentryへのクラッシュレポート送信に同意したか
+    "telemetry_consent_asked": False,     # 初回同意ダイアログを表示済みか（True かつ False は明示的拒否を意味する）
 }
 
 VALID_TRANSLATE_MODES = {"自動", "英→日", "日→英"}
@@ -266,7 +269,10 @@ def validate_config(config_data):
         validated["log_level"] = log_level
 
     # ブール値はbool化
-    for key in ["voicevox_auto_start", "auto_update_check", "include_prerelease", "archive_enabled"]:
+    for key in [
+        "voicevox_auto_start", "auto_update_check", "include_prerelease", "archive_enabled",
+        "telemetry_crash_reporting", "telemetry_consent_asked",
+    ]:
         if not isinstance(validated.get(key), bool):
             validated[key] = bool(validated.get(key))
             changed = True

--- a/src/gui.py
+++ b/src/gui.py
@@ -302,6 +302,10 @@ class KototsunaApp:
         # アップデート設定
         self.auto_update_check = tk.BooleanVar(value=self.config.get("auto_update_check", True))
         self.include_prerelease = tk.BooleanVar(value=self.config.get("include_prerelease", False))
+        # テレメトリ（クラッシュレポート、Issue #208）
+        self.telemetry_crash_reporting = tk.BooleanVar(
+            value=self.config.get("telemetry_crash_reporting", False)
+        )
 
         # エモート画像キャッシュ
         self._emote_pil_cache: Dict[str, Optional[Image.Image]] = {}
@@ -393,6 +397,8 @@ class KototsunaApp:
         # 起動時にアップデートを確認（セーフモードではスキップ）
         if not self.safe_mode:
             self.master.after(3000, self._check_for_updates_on_startup)
+        # 初回起動時にクラッシュレポート送信の同意を確認（Issue #208）
+        self.master.after(2000, self._maybe_show_telemetry_consent)
 
         if self.safe_mode:
             logger.info("セーフモードで起動: OBS自動連携・VOICEVOX自動起動・アップデート確認を無効化")
@@ -1701,6 +1707,21 @@ class KototsunaApp:
                 font=("Segoe UI", 10),
             )
             self._rollback_btn.pack(fill="x", pady=(8, 0))
+
+        self._add_panel_divider(parent)
+
+        # プライバシー / クラッシュレポート（Issue #208）
+        self._add_panel_section(parent, "プライバシー")
+        ctk.CTkCheckBox(
+            parent, text="クラッシュレポートを送信する",
+            variable=self.telemetry_crash_reporting, font=("Segoe UI", 10),
+        ).pack(anchor="w", pady=2)
+        ctk.CTkLabel(
+            parent,
+            text="不具合修正のため、エラー発生時のスタックトレースを匿名で開発者に送信します。\nチャンネル名・コメント本文・トークン等の個人情報は送信されません。\n設定変更は次回起動時に反映されます。",
+            font=("Segoe UI", 9), text_color=TEXT_SUBTLE,
+            justify="left", wraplength=320,
+        ).pack(anchor="w", padx=(24, 0), pady=(0, 4))
 
         self._add_panel_divider(parent)
 
@@ -4353,6 +4374,7 @@ class KototsunaApp:
             self.tts_include_name_var.set(cfg.get("tts_include_name", False))
             self.auto_update_check.set(cfg.get("auto_update_check", True))
             self.include_prerelease.set(cfg.get("include_prerelease", False))
+            self.telemetry_crash_reporting.set(cfg.get("telemetry_crash_reporting", False))
         except Exception as e:
             logger.error(f"Failed to apply config to GUI: {e}", exc_info=True)
 
@@ -4891,6 +4913,7 @@ class KototsunaApp:
             self.config["tts_include_name"] = self.tts_include_name_var.get()
             self.config["auto_update_check"] = self.auto_update_check.get()
             self.config["include_prerelease"] = self.include_prerelease.get()
+            self.config["telemetry_crash_reporting"] = self.telemetry_crash_reporting.get()
 
             # VOICEVOX Managerのパスを更新
             if self.voicevox_path.get().strip() and hasattr(self, "voicevox_manager"):
@@ -6513,6 +6536,107 @@ class KototsunaApp:
         else:
             self.log_message(f"⚠️ BOT起動失敗: {err_msg}")
             self._set_status("BOT起動失敗", "error")
+
+    # =========================================
+    # クラッシュレポート同意ダイアログ（Issue #208）
+    # =========================================
+
+    def _maybe_show_telemetry_consent(self) -> None:
+        """初回起動時にクラッシュレポート送信の同意を求めるダイアログを出す。
+
+        config["telemetry_consent_asked"] が True なら何もしない。
+        ユーザーが「あとで決める」を選んだ場合は consent_asked を更新せず、次回起動時に再表示する。
+        """
+        if self.config.get("telemetry_consent_asked", False):
+            return
+        try:
+            self._show_telemetry_consent_dialog()
+        except Exception as e:
+            logger.error(f"Failed to show telemetry consent dialog: {e}", exc_info=True)
+
+    def _show_telemetry_consent_dialog(self) -> None:
+        dialog = ctk.CTkToplevel(self.master)
+        dialog.title("クラッシュレポートのご協力のお願い")
+        dialog.geometry("520x420")
+        dialog.resizable(False, False)
+        dialog.transient(self.master)
+        dialog.grab_set()
+
+        ctk.CTkLabel(
+            dialog, text="クラッシュレポートを送信しますか？",
+            font=("Segoe UI Semibold", 16),
+        ).pack(pady=(20, 8))
+
+        body_text = (
+            "ことつな！の品質向上にご協力ください。\n\n"
+            "✅ 送信される情報:\n"
+            "    ・エラー内容（例外型・メッセージ）\n"
+            "    ・スタックトレース（発生箇所のファイル名・行番号）\n"
+            "    ・アプリのバージョン / OS / Python のバージョン\n\n"
+            "❌ 送信されない情報:\n"
+            "    ・チャンネル名・配信者名・視聴者名\n"
+            "    ・コメント本文・メッセージ内容\n"
+            "    ・OAuth トークン・パスワード等の認証情報\n"
+            "    ・IP アドレス・個人を特定できる情報\n\n"
+            "あとから設定画面でいつでも変更できます。"
+        )
+        ctk.CTkLabel(
+            dialog, text=body_text,
+            font=("Segoe UI", 10),
+            justify="left", wraplength=480,
+        ).pack(padx=20, pady=(0, 12), anchor="w")
+
+        btn_frame = ctk.CTkFrame(dialog, fg_color="transparent")
+        btn_frame.pack(fill="x", padx=20, pady=(0, 16))
+
+        def _decide(send: bool) -> None:
+            self.config["telemetry_crash_reporting"] = send
+            self.config["telemetry_consent_asked"] = True
+            try:
+                self.telemetry_crash_reporting.set(send)
+            except Exception:
+                pass
+            try:
+                save_config(self.config)
+            except Exception as e:
+                logger.error(f"Failed to save telemetry consent: {e}", exc_info=True)
+            if send:
+                # 同意したら即座に init を試みる（次回起動を待たずに済むケース）
+                try:
+                    from src.sentry_init import init_sentry
+                    init_sentry(True)
+                except Exception:
+                    pass
+            self.log_message(
+                "✅ クラッシュレポートを送信します（設定画面で変更可）" if send
+                else "クラッシュレポートを送信しません（設定画面で変更可）"
+            )
+            dialog.destroy()
+
+        def _later() -> None:
+            # consent_asked を立てないので次回起動時に再表示
+            dialog.destroy()
+
+        ctk.CTkButton(
+            btn_frame, text="送信する",
+            command=lambda: _decide(True),
+            width=140, fg_color=ACCENT, hover_color="#1CA04E",
+        ).pack(side="left", padx=(0, 8))
+
+        ctk.CTkButton(
+            btn_frame, text="送信しない",
+            command=lambda: _decide(False),
+            width=120, fg_color="gray",
+        ).pack(side="left", padx=(0, 8))
+
+        ctk.CTkButton(
+            btn_frame, text="あとで決める",
+            command=_later,
+            width=120, fg_color="transparent", border_width=1,
+        ).pack(side="left")
+
+        # × ボタンで閉じた場合は「あとで」扱い
+        dialog.protocol("WM_DELETE_WINDOW", _later)
 
     # =========================================
     # アップデート関連メソッド

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,31 @@ def test_stt_num_threads_default():
     assert validated["stt_num_threads"] == 2
 
 
+# --- Telemetry config tests (Issue #208) ---
+
+
+def test_telemetry_keys_default_to_false():
+    validated, _ = validate_config({})
+    assert validated["telemetry_crash_reporting"] is False
+    assert validated["telemetry_consent_asked"] is False
+
+
+def test_telemetry_crash_reporting_coerced_to_bool():
+    validated, changed = validate_config({"telemetry_crash_reporting": "yes"})
+    assert validated["telemetry_crash_reporting"] is True
+    assert changed is True
+
+
+def test_telemetry_consent_asked_preserves_explicit_false():
+    """ユーザーが明示的に「送信しない」を選んだ場合、再ダイアログ表示しないこと。"""
+    validated, _ = validate_config({
+        "telemetry_consent_asked": True,
+        "telemetry_crash_reporting": False,
+    })
+    assert validated["telemetry_consent_asked"] is True
+    assert validated["telemetry_crash_reporting"] is False
+
+
 def test_stt_num_threads_clamped():
     validated, _ = validate_config({"stt_num_threads": 20})
     assert validated["stt_num_threads"] == 8


### PR DESCRIPTION
## 概要

Issue #208 の **PR2**。クラッシュレポート送信のオプトインUIと設定キーを追加します。
PR1 で土台のみ作った Sentry 配線を、ユーザー同意のもとで実際に有効化する仕組みです。

## 変更点

### 設定 (`src/config.py`)
- `telemetry_crash_reporting`: bool（デフォルト `False`） - 送信に同意したか
- `telemetry_consent_asked`: bool（デフォルト `False`） - 同意ダイアログを表示済みか
- 両キーとも `validate_config` で bool 強制

### 起動時初期化 (`main.py`)
- ロガー初期化直後に `load_config()` → `init_sentry(crash_reporting)` を呼ぶ
- 同意なし、SDK欠落、初期化失敗のいずれでも本体起動には影響しない

### 初回起動同意ダイアログ (`src/gui.py`)
- アプリ起動 2 秒後に表示（`telemetry_consent_asked == False` のときのみ）
- 「送信される情報 / 送信されない情報」を明示
- 3択:
  - **「送信する」**: 即時 `init_sentry(True)` も呼ぶ → 設定保存 → 同意フラグ ON
  - **「送信しない」**: 拒否を保存 → 同意フラグ ON
  - **「あとで決める」**: 同意フラグを立てず次回再表示
- ダイアログ × ボタンも「あとで」扱い

### 設定画面トグル (`src/gui.py`)
- 設定パネルに「プライバシー」セクション追加
- チェックボックス＋送信される/されない情報の説明文を併記
- 設定変更は次回起動で反映（同意ダイアログから「送信する」を選んだケースのみ即時 init）

## テスト

- `tests/test_config.py` に 3件追加
  - `test_telemetry_keys_default_to_false`
  - `test_telemetry_crash_reporting_coerced_to_bool`
  - `test_telemetry_consent_asked_preserves_explicit_false`
- 既存 + 新規 = **35件全パス**（ローカル `uv run pytest` で確認済み）

## 動作確認の流れ

1. アプリ初回起動 → 同意ダイアログが出る
2. 「送信する」を選ぶ → `1/0` を意図的に発生させる → Sentry に届く
3. 「送信しない」を選ぶ → 例外を出しても Sentry には何も届かない
4. 「あとで」を選ぶ → アプリ再起動で再びダイアログが出る
5. 設定画面でトグル → 再起動後に有効化／無効化が反映

## リリース計画

PR3 / PR4 を積んだあと、まずベータ版で配布検証してから `1.9.0` 安定版に乗せる。

## Test plan

- [ ] CI で全テストグリーン
- [ ] Windows ローカルで初回起動時にダイアログ表示
- [ ] 「送信する」選択後に意図的なクラッシュが Sentry Issues に表示される
- [ ] 「あとで」選択後、再起動でダイアログが再表示される
- [ ] 設定画面のトグルが config.json に反映される

Refs #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
