### PR TITLE
feat: クラッシュ後のフィードバックダイアログと「問題を報告」ボタン (#208 PR3)

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -44,6 +44,7 @@ from src.overlay_server import (
     set_chat_config as overlay_set_chat_config,
 )
 from src.logger import logger, set_log_level
+from src.sentry_init import register_post_capture_callback, submit_feedback, get_last_event_id
 from src.tts import get_tts_instance
 import src.channel_manager as channel_manager
 from src.tts_dictionary import get_dictionary
@@ -399,6 +400,11 @@ class KototsunaApp:
             self.master.after(3000, self._check_for_updates_on_startup)
         # 初回起動時にクラッシュレポート送信の同意を確認（Issue #208）
         self.master.after(2000, self._maybe_show_telemetry_consent)
+        # クラッシュ捕捉後に再現手順入力ダイアログを出すためのコールバックを登録（Issue #208 PR3）
+        try:
+            register_post_capture_callback(self._on_sentry_event_captured)
+        except Exception as e:
+            logger.error(f"Failed to register sentry capture callback: {e}", exc_info=True)
 
         if self.safe_mode:
             logger.info("セーフモードで起動: OBS自動連携・VOICEVOX自動起動・アップデート確認を無効化")
@@ -1722,6 +1728,12 @@ class KototsunaApp:
             font=("Segoe UI", 9), text_color=TEXT_SUBTLE,
             justify="left", wraplength=320,
         ).pack(anchor="w", padx=(24, 0), pady=(0, 4))
+        ctk.CTkButton(
+            parent, text="💬 問題を報告",
+            command=self._open_manual_feedback_dialog,
+            fg_color="#6366F1", hover_color="#4F46E5", height=28,
+            font=("Segoe UI", 10),
+        ).pack(fill="x", pady=(4, 4))
 
         self._add_panel_divider(parent)
 
@@ -6637,6 +6649,119 @@ class KototsunaApp:
 
         # × ボタンで閉じた場合は「あとで」扱い
         dialog.protocol("WM_DELETE_WINDOW", _later)
+
+    # =========================================
+    # クラッシュフィードバックダイアログ（Issue #208 PR3）
+    # =========================================
+
+    def _on_sentry_event_captured(self, event_id: str) -> None:
+        """Sentryが例外を捕捉したときに呼ばれる。メインスレッドでダイアログ表示をスケジュール。
+
+        例外発生スレッドから呼ばれるため、Tk操作はメインスレッドへ戻すこと。
+        """
+        try:
+            self.master.after(0, lambda: self._show_feedback_dialog(event_id, after_crash=True))
+        except Exception:
+            pass
+
+    def _show_feedback_dialog(self, event_id: Optional[str], after_crash: bool) -> None:
+        """ユーザーに再現手順や状況の説明を任意で書いてもらうダイアログ。
+
+        after_crash=True: クラッシュ直後に出すモード（タイトルや説明文が変わる）
+        after_crash=False: 設定画面の「問題を報告」ボタンから呼ぶモード
+        """
+        # 連発抑止: 既に開いているなら何もしない
+        if getattr(self, "_feedback_dialog_open", False):
+            return
+        # クラッシュ後モードでテレメトリOFFなら何もしない（送信できないので）
+        if after_crash and not self.config.get("telemetry_crash_reporting", False):
+            return
+
+        self._feedback_dialog_open = True
+
+        dialog = ctk.CTkToplevel(self.master)
+        dialog.title("問題のご報告" if after_crash else "問題を報告")
+        dialog.geometry("520x440")
+        dialog.resizable(False, False)
+        dialog.transient(self.master)
+        dialog.grab_set()
+
+        title = "エラーが発生しました" if after_crash else "問題を報告する"
+        ctk.CTkLabel(
+            dialog, text=title,
+            font=("Segoe UI Semibold", 16),
+        ).pack(pady=(20, 4))
+
+        sub = (
+            "もしよければ、何をしようとしていたか教えてください。\n"
+            "再現手順がわかれば修正の助けになります（任意）。"
+            if after_crash else
+            "発生している不具合や改善要望を送信できます。\n"
+            "クラッシュ直後でなくても送信可能です（任意）。"
+        )
+        ctk.CTkLabel(
+            dialog, text=sub,
+            font=("Segoe UI", 10), text_color=TEXT_SUBTLE,
+            justify="left", wraplength=480,
+        ).pack(padx=20, pady=(0, 8), anchor="w")
+
+        textbox = ctk.CTkTextbox(dialog, height=200, font=("Segoe UI", 11))
+        textbox.pack(fill="both", expand=True, padx=20, pady=(0, 8))
+        textbox.focus_set()
+
+        if event_id:
+            ctk.CTkLabel(
+                dialog, text=f"Event ID: {event_id[:12]}…",
+                font=("Consolas", 9), text_color=TEXT_SUBTLE,
+            ).pack(anchor="w", padx=20)
+
+        btn_frame = ctk.CTkFrame(dialog, fg_color="transparent")
+        btn_frame.pack(fill="x", padx=20, pady=(8, 16))
+
+        def _on_close() -> None:
+            self._feedback_dialog_open = False
+            dialog.destroy()
+
+        def _send() -> None:
+            msg = textbox.get("1.0", "end").strip()
+            if not msg:
+                _on_close()
+                return
+            ok = False
+            try:
+                ok = submit_feedback(msg, event_id=event_id)
+            except Exception as e:
+                logger.error(f"Failed to submit feedback: {e}", exc_info=True)
+            if ok:
+                self.log_message("✅ ご報告を送信しました。ありがとうございます")
+            else:
+                self.log_message("⚠️ 報告の送信に失敗しました（次回起動時に再送はされません）")
+            _on_close()
+
+        ctk.CTkButton(
+            btn_frame, text="送信",
+            command=_send,
+            width=120, fg_color=ACCENT, hover_color="#1CA04E",
+        ).pack(side="left", padx=(0, 8))
+
+        ctk.CTkButton(
+            btn_frame, text="送信しない",
+            command=_on_close,
+            width=120, fg_color="gray",
+        ).pack(side="left")
+
+        dialog.protocol("WM_DELETE_WINDOW", _on_close)
+
+    def _open_manual_feedback_dialog(self) -> None:
+        """設定画面の「問題を報告」ボタンから呼ぶ手動フィードバック。"""
+        if not self.config.get("telemetry_crash_reporting", False):
+            messagebox.showinfo(
+                "クラッシュレポート未有効",
+                "問題報告を送信するには、プライバシー設定でクラッシュレポートを有効にしてください。",
+                parent=self.master,
+            )
+            return
+        self._show_feedback_dialog(get_last_event_id(), after_crash=False)
 
     # =========================================
     # アップデート関連メソッド

--- a/src/sentry_init.py
+++ b/src/sentry_init.py
@@ -16,10 +16,15 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from src import __version__
 from src.logger import _mask_secrets
+
+# 最後に捕捉した Sentry イベント ID（ユーザーフィードバック紐付け用、PR3）
+_last_event_id: Optional[str] = None
+# 例外捕捉時に呼ばれるコールバック（GUI 側でフィードバックダイアログを出す用、PR3）
+_post_capture_callback: Optional[Callable[[str], None]] = None
 
 # 公開可能な DSN 定数（Sentry 設計上、クライアント配布アプリでは公開で問題ない）
 # 環境変数 KOTOTSUNA_SENTRY_DSN で上書き可能
@@ -109,8 +114,17 @@ def _install_tk_excepthook() -> None:
     _original = tk.Tk.report_callback_exception
 
     def _hooked(self, exc, val, tb):
+        global _last_event_id
         try:
-            sentry_sdk.capture_exception((exc, val, tb))
+            event_id = sentry_sdk.capture_exception((exc, val, tb))
+            if event_id:
+                _last_event_id = event_id
+                # フィードバックダイアログ等のコールバックを発火（登録されていれば）
+                if _post_capture_callback is not None:
+                    try:
+                        _post_capture_callback(event_id)
+                    except Exception:
+                        pass
         except Exception:
             pass
         try:
@@ -119,6 +133,72 @@ def _install_tk_excepthook() -> None:
             pass
 
     tk.Tk.report_callback_exception = _hooked  # type: ignore[assignment]
+
+
+def register_post_capture_callback(callback: Optional[Callable[[str], None]]) -> None:
+    """例外捕捉後に呼ばれるコールバックを登録する（GUI でフィードバックUIを出す用）。
+
+    callback は event_id を引数に取る。GUI 側は after() でメインスレッドに戻すこと。
+    None を渡すと解除。
+    """
+    global _post_capture_callback
+    _post_capture_callback = callback
+
+
+def get_last_event_id() -> Optional[str]:
+    """最後に Sentry が捕捉したイベント ID を返す（無ければ None）。"""
+    return _last_event_id
+
+
+def submit_feedback(message: str, name: str = "", email: str = "",
+                    event_id: Optional[str] = None) -> bool:
+    """ユーザー入力フィードバックを Sentry に送信する。
+
+    Args:
+        message: ユーザーが書いた再現手順や説明。空なら送信しない。
+        name: 任意の表示名。
+        email: 任意のメールアドレス。
+        event_id: 紐付けたい Sentry イベント ID。None なら直近の捕捉ID。
+
+    Returns:
+        送信を試みた場合 True、SDK欠落・メッセージ空・例外などで送らなかった場合 False。
+    """
+    if not message or not message.strip():
+        return False
+    try:
+        import sentry_sdk
+    except ImportError:
+        return False
+
+    target_event_id = event_id or _last_event_id
+
+    try:
+        # sentry-sdk 2.7+ は capture_feedback、それ以前は capture_user_feedback。
+        # 両対応で捕捉する。
+        if hasattr(sentry_sdk, "capture_feedback"):
+            sentry_sdk.capture_feedback(
+                {
+                    "message": message.strip(),
+                    "name": name.strip() or None,
+                    "contact_email": email.strip() or None,
+                    "associated_event_id": target_event_id,
+                }
+            )
+        elif hasattr(sentry_sdk, "capture_user_feedback") and target_event_id:
+            sentry_sdk.capture_user_feedback(
+                {
+                    "event_id": target_event_id,
+                    "name": name.strip() or "anonymous",
+                    "email": email.strip() or "anonymous@example.com",
+                    "comments": message.strip(),
+                }
+            )
+        else:
+            return False
+    except Exception as e:
+        _module_logger.warning(f"[Sentry] feedback送信に失敗: {e}")
+        return False
+    return True
 
 
 def init_sentry(enabled: bool, dsn: Optional[str] = None) -> bool:

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -107,3 +107,31 @@ def test_redact_mapping_masks_strings():
     data = {"note": "token leaked: oauth:abcdef1234567890"}
     out = _redact_mapping(data)
     assert "oauth:***" in out["note"]
+
+
+# --- User feedback (PR3) ---
+
+
+def test_submit_feedback_returns_false_for_empty_message():
+    from src.sentry_init import submit_feedback
+    assert submit_feedback("") is False
+    assert submit_feedback("   ") is False
+    assert submit_feedback("\n\t\n") is False
+
+
+def test_register_and_get_last_event_id_lifecycle():
+    """callback 登録解除と event_id ゲッターが安全に動くこと。"""
+    from src.sentry_init import register_post_capture_callback, get_last_event_id
+
+    captured = []
+
+    def _cb(event_id):
+        captured.append(event_id)
+
+    register_post_capture_callback(_cb)
+    register_post_capture_callback(None)  # 解除しても落ちないこと
+
+    # initial state: 何も捕捉されてないなら None
+    # （他テストで設定された値が残っている可能性はあるので型チェックのみ）
+    last = get_last_event_id()
+    assert last is None or isinstance(last, str)


### PR DESCRIPTION
## 概要

Issue #208 の **PR3**。クラッシュ後にユーザーが任意で再現手順を書けるダイアログと、設定画面の「問題を報告」ボタンを追加します。

## 変更点

### `src/sentry_init.py`
- `register_post_capture_callback(callback)` / `get_last_event_id()` を追加
- `_install_tk_excepthook` 内で `capture_exception` の戻り値（event_id）を保持
- `submit_feedback(message, name, email, event_id)` を追加
  - sentry-sdk 2.7+ の `capture_feedback` と旧 `capture_user_feedback` の両対応
  - 空メッセージは送信せず False を返す

### `src/gui.py`
- `_on_sentry_event_captured(event_id)`: 例外スレッドから呼ばれてもメインスレッドにディスパッチ
- `_show_feedback_dialog(event_id, after_crash)`:
  - **クラッシュ直後モード**: 「何をしようとしていたか教えてください（任意）」
  - **手動モード**: 設定パネルの「💬 問題を報告」ボタン経由
- 連発抑止: `_feedback_dialog_open` フラグで多重表示を防止
- 設定パネルの「プライバシー」セクションに **「💬 問題を報告」ボタン** を追加
  - テレメトリ未同意時は messagebox で「先に設定を有効化してください」と案内

## 動作確認の流れ

1. テレメトリ有効状態で意図的に Tkinter コールバックエラーを起こす
2. クラッシュ直後にフィードバックダイアログが出る → 説明を入力 → 送信
3. Sentry の該当 Issue にユーザーフィードバックが紐付けられる
4. クラッシュ無しで「問題を報告」ボタンを押す → 直近 event_id（無ければ event_id 無し）で送信できる
5. テレメトリ未同意時に「問題を報告」を押す → 案内メッセージが表示

## テスト

- `tests/test_sentry_init.py` に 2件追加
  - `test_submit_feedback_returns_false_for_empty_message`
  - `test_register_and_get_last_event_id_lifecycle`
- 全 37件パス（ローカル `uv run pytest` で確認済み）

## リリース計画

PR4（ドキュメント追加）を積んだあと、まずベータ版で配布検証してから `1.9.0` 安定版に乗せる。

## Test plan

- [ ] CI で全テストグリーン
- [ ] Windows ローカルでテレメトリ有効化 → 意図的クラッシュ → フィードバック送信
- [ ] テレメトリ無効状態でボタン押下 → 案内メッセージ
- [ ] Sentry 管理画面で User Feedback が表示されること

Refs #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)
